### PR TITLE
Add Storybook build job for component documentation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,3 +114,47 @@ jobs:
         token: ${{ github.token }}
         state: success
         deployment-id: ${{ steps.deployment-prod.outputs.deployment_id }}
+
+  # Add a storybook job for component documentation and testing
+  storybook:
+    name: Storybook Build
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ env.NODE_VERSION }}
+        cache: 'npm'
+    
+    - name: Install dependencies
+      run: npm ci ${{ env.NPM_FLAGS }}
+      
+    - name: Check for Storybook
+      id: check-storybook
+      run: |
+        if [ -f ".storybook/main.js" ] || [ -f ".storybook/main.ts" ]; then
+          echo "has_storybook=true" >> $GITHUB_OUTPUT
+        else
+          echo "has_storybook=false" >> $GITHUB_OUTPUT
+          echo "No Storybook configuration found. Skipping Storybook build."
+        fi
+        
+    - name: Build Storybook
+      if: steps.check-storybook.outputs.has_storybook == 'true'
+      run: |
+        # If storybook is in devDependencies but not installed globally
+        npx storybook build -o storybook-static
+      continue-on-error: true
+        
+    - name: Upload Storybook
+      if: steps.check-storybook.outputs.has_storybook == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: storybook
+        path: storybook-static
+        retention-days: 30


### PR DESCRIPTION
Added a Storybook build job to the CI/CD workflow that automatically builds and saves the Storybook artifact when Storybook configuration is detected. This job runs on both PR and main branch workflows, making component documentation easily accessible.