### PR TITLE
Migrate to WebSocket-based token data

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -14,6 +14,7 @@ const DEV_PORT = "3005";
 const LOCAL_PORT = "3006"; // almost NEVER if EVER used
 // NODE_ENV gets set and exported; is either "development" or "production"
 export const NODE_ENV = isDev ? "development" : "production";
+// ^ Note: I'm going to allow this to stay exported for now but the new preferred method is to just use the config object at config.ENV.NODE_ENV
 
 /* Debug Mode */
 export const DDAPI_DEBUG_MODE = isDev ? "true" : "false";
@@ -170,6 +171,12 @@ const RELEASE_DATE_END_OF_LAUNCH_PARTY_FESTIVITIES = new Date(RELEASE_DATE_TOKEN
 
 // Config export
 export const config = {
+  // Environment
+  ENV: {
+    NODE_ENV: NODE_ENV,
+    IS_DEV: isDev,
+    IS_PROD: !isDev
+  },
   CONTRACT_ADDRESS: {
     REAL: CONTRACT_ADDRESS_REAL,
     FAKE: CONTRACT_ADDRESS_FAKE

--- a/src/hooks/useTokenData.ts
+++ b/src/hooks/useTokenData.ts
@@ -1,3 +1,5 @@
+// src/hooks/useTokenData.ts
+
 /**
  * Token Data Hook
  * 
@@ -8,7 +10,11 @@
 import { useCallback, useEffect, useState } from "react";
 import { MessageType, TopicType } from "./websocket";
 import { useWebSocketTopic } from "./websocket/useWebSocketTopic";
-import { NODE_ENV } from "../config/config";
+
+// Config
+import { config } from "../config/config";
+const NODE_ENV = config.ENV.NODE_ENV;
+const VERBOSE_USETOKENDATA_LOGGING = 'true'; // (quick fix) Logging verbosity
 
 export interface TokenData {
   symbol: string;
@@ -79,6 +85,10 @@ export function useTokenData(
     try {
       if (NODE_ENV === "development") {
         console.log(`[TokenData] Received message:`, message);
+      } else {
+        if (VERBOSE_USETOKENDATA_LOGGING === "true") {
+          console.log(`[TokenData] Received message:`, message);
+        }
       }
 
       // Handle token data messages


### PR DESCRIPTION
## Summary
- Begin migration from deprecated /dd-serv/tokens API endpoints to WebSocket-based token data system
- Update useTokenData.ts with improved logging and configuration

## Test plan
- Verify all token data is correctly fetched via WebSocket
- Check that components display token data properly
- Ensure real-time updates work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)